### PR TITLE
error function not defined if ARCHDEFS not set

### DIFF
--- a/bin/install_optrove
+++ b/bin/install_optrove
@@ -55,7 +55,7 @@ let install_archdefs=0
 if (( $install_archdefs )) ; then
   if [[ -z "$ARCHDEFS" || ! -f "$ARCHDEFS/version" ]]; then
     if [[ ! -d "$PWD/../archdefs" || ! -f "$PWD/../archdefs/version" ]]; then
-      error 'environment variable ARCHDEFS is not set, nor does the
+      echo 'environment variable ARCHDEFS is not set, nor does the
  directory ../archdefs exist. Install the ARCHDefs package, set
  the variable $ARCHDEFS to the archdefs directory and re-run.'
       exit 1


### PR DESCRIPTION
If `ARCHDEFS` is not set, the `error()` function is called before `helper_functions` has been sourced.