### PR TITLE
add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+on: 
+  push:
+    branches:
+      - master
+      - main
+
+jobs:
+  release-on-push:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: rymndhng/release-on-push-action@master
+        id: release
+        with:
+          # add a label to your pull request to change the default behavior:
+          # release:major
+          # release:minor
+          # release:patch
+          # norelease
+          bump_version_scheme: patch
+          tag_prefix: v
+          release_body: ""
+          use_github_release_notes: true
+
+      - name: Build PR comment
+        uses: thollander/actions-comment-pull-request@v1
+        with:
+          message: "Generated tag ${{ steps.release.outputs.tag_name }} and release version ${{ steps.release.outputs.version }}"


### PR DESCRIPTION
@nimgould @amontoison @jfowkes

Here is a workflow that automatically creates a new release every time a pull request is merged. When we're happy with the settings, I'll add it to SIFDecode, CUTEst and GALAHAD (once it has stabilized).

The main ideas are that
- we never commit directly to `master` any more;
- all changes are made via pull requests;
- the version number uses [semantic versioning](www.semver.org);
- each time a pull request is merged, the patch number of the version is incremented and a new release is published;
- we can override the default behavior by applying a label to the pull request (labels are on the right side of the page 👉 );
- the labels are `release:major`, `release:minor`, `release:patch` and `norelease`;
- I've applied the `norelease` label to this pull request because it doesn't warrant a new release;
- if all goes well, a comment will be added to the recently merged pull request stating the new version number (just for the record).

Does this seem convenient?