### PR TITLE
Use FORTRAN=gfortran not gfortran-12

### DIFF
--- a/compiler.mac64.osx.gfo
+++ b/compiler.mac64.osx.gfo
@@ -3,7 +3,7 @@
 # Fortran compilation and loading
 #
 
-FORTRAN='gfortran-12'
+FORTRAN='gfortran'
 BASIC='-c -fPIC -fno-second-underscore -flat_namespace -cpp'
 MBASIC='-fPIC -fno-second-underscore -flat_namespace'
 LIBCMD=''

--- a/compiler.pc64.lnx.gfo
+++ b/compiler.pc64.lnx.gfo
@@ -3,7 +3,7 @@
 # Fortran compilation and loading
 #
 
-FORTRAN='gfortran-12'
+FORTRAN='gfortran'
 BASIC='-c -fno-second-underscore -fPIC'
 MBASIC='-fno-second-underscore -fPIC'
 LIBCMD=''


### PR DESCRIPTION
@dalekopera @nimgould can we please use FORTRAN=gfortran not FORTRAN=gfortran-12 on Linux and Mac as many users do no yet have gfortran v12 installed on their systems. I have already had two bug reports from PyCUTEst users for which this breaks their CUTEst installs.