### PR TITLE
compiler.mac64.osx.gfo: use gfortran-14

### DIFF
--- a/compiler.mac64.osx.gfo
+++ b/compiler.mac64.osx.gfo
@@ -3,7 +3,7 @@
 # Fortran compilation and loading
 #
 
-FORTRAN='gfortran-13'
+FORTRAN='gfortran-14'
 BASIC='-c -fPIC -fno-second-underscore -flat_namespace -cpp'
 MBASIC='-fPIC -fno-second-underscore -flat_namespace -cpp'
 I8='-finteger-4-integer-8'


### PR DESCRIPTION
Homebrew now installs gcc/gfortran 14.